### PR TITLE
feat: 多星球配置+切换系统 #7

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -5,8 +5,10 @@ import { CameraSystem } from './core/Camera';
 import { InputManager } from './core/InputManager';
 import type { IDisposable } from './core/types';
 import { PlanetFactory } from './planet/PlanetFactory';
+import type { PlanetType } from './planet/PlanetFactory';
 import { cartesianToGeo } from './utils/geo';
 import { HUD } from './ui/HUD';
+import { PlanetSelector } from './ui/PlanetSelector';
 import { PlayerController } from './player/PlayerController';
 
 /** 主控制器：组装各子系统，驱动渲染循环 */
@@ -16,9 +18,11 @@ export class App implements IDisposable {
   private cameraSystem: CameraSystem;
   private inputManager: InputManager;
   private hud: HUD;
+  private planetSelector: PlanetSelector;
   private playerController: PlayerController;
   private clock = new THREE.Clock();
   private animationId = 0;
+  private currentPlanet: PlanetType = 'earth';
 
   constructor(canvas: HTMLCanvasElement) {
     this.engine = new Engine({
@@ -28,17 +32,23 @@ export class App implements IDisposable {
       pixelRatio: Math.min(window.devicePixelRatio, 2),
     });
 
-    const planet = PlanetFactory.createEarth();
+    const planet = PlanetFactory.create(this.currentPlanet);
     this.sceneManager = new SceneManager(planet);
     this.cameraSystem = new CameraSystem();
     this.inputManager = new InputManager(canvas);
     this.hud = new HUD();
+    this.planetSelector = new PlanetSelector({
+      initialPlanet: this.currentPlanet,
+      onPlanetSelect: this.switchPlanet,
+    });
 
     this.playerController = new PlayerController({
       camera: this.cameraSystem.camera,
       input: this.inputManager,
       planetCenter: new THREE.Vector3(0, 0, 0),
+      planetId: this.currentPlanet,
       planetRadius: planet.config.radius,
+      gravity: planet.config.gravity,
       surfaceMeshes: [planet.mesh],
     });
 
@@ -48,6 +58,24 @@ export class App implements IDisposable {
   private onResize = (): void => {
     this.engine.resize();
     this.cameraSystem.resize();
+  };
+
+  private switchPlanet = (planetType: PlanetType): void => {
+    if (planetType === this.currentPlanet) {
+      return;
+    }
+
+    const nextPlanet = PlanetFactory.create(planetType);
+    this.sceneManager.replacePlanet(nextPlanet);
+    this.playerController.switchPlanet({
+      planetId: planetType,
+      planetRadius: nextPlanet.config.radius,
+      gravity: nextPlanet.config.gravity,
+      surfaceMeshes: [nextPlanet.mesh],
+    });
+
+    this.currentPlanet = planetType;
+    this.planetSelector.setActive(planetType);
   };
 
   start(): void {
@@ -78,6 +106,7 @@ export class App implements IDisposable {
     this.playerController.dispose();
     this.inputManager.dispose();
     this.hud.dispose();
+    this.planetSelector.dispose();
     this.sceneManager.dispose();
     this.engine.dispose();
   }

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -7,7 +7,7 @@ import { Planet } from '../planet/Planet';
 export class SceneManager implements IDisposable {
   readonly scene: THREE.Scene;
 
-  private readonly planet: Planet;
+  private planet: Planet;
   private skybox!: THREE.Mesh<THREE.SphereGeometry, THREE.ShaderMaterial>;
   private stars!: THREE.Points<THREE.BufferGeometry, THREE.ShaderMaterial>;
   private sunLight!: THREE.DirectionalLight;
@@ -29,6 +29,13 @@ export class SceneManager implements IDisposable {
 
   get planetRadius(): number {
     return this.planet.config.radius;
+  }
+
+  replacePlanet(planet: Planet): void {
+    this.scene.remove(this.planet.root);
+    this.planet.dispose();
+    this.planet = planet;
+    this.addPlanet();
   }
 
   private addPlanet(): void {

--- a/src/planet/PlanetConfig.ts
+++ b/src/planet/PlanetConfig.ts
@@ -27,6 +27,14 @@ export interface TerrainConfig {
   tileResolution?: number;
 }
 
+/** 预设兴趣点（地标） */
+export interface PlanetLandmark {
+  name: string;
+  lat: number;
+  lng: number;
+  description?: string;
+}
+
 /** 星球配置 */
 export interface PlanetConfig {
   name: string;
@@ -37,4 +45,5 @@ export interface PlanetConfig {
   textures: PlanetTextureConfig;
   atmosphere?: AtmosphereConfig;
   terrain?: TerrainConfig;
+  landmarks: PlanetLandmark[];
 }

--- a/src/planet/PlanetFactory.ts
+++ b/src/planet/PlanetFactory.ts
@@ -28,6 +28,10 @@ const PLANET_CONFIGS: Record<PlanetType, PlanetConfig> = {
       maxLodLevel: 15,
       tileResolution: 256,
     },
+    landmarks: [
+      { name: 'Mount Everest', lat: 27.9881, lng: 86.925, description: 'Earth highest peak' },
+      { name: 'Grand Canyon', lat: 36.1069, lng: -112.1129, description: 'Colorado Plateau canyon system' },
+    ],
   },
   mars: {
     name: 'mars',
@@ -35,9 +39,13 @@ const PLANET_CONFIGS: Record<PlanetType, PlanetConfig> = {
     gravity: MARS_GRAVITY,
     segments: 128,
     textures: {
+      // NASA Mars Global Surveyor / Viking global color mosaic
       diffusePath: '/assets/textures/mars/diffuse.jpg',
+      // MOLA-derived normal map for macro terrain details
       normalPath: '/assets/textures/mars/normal.jpg',
+      // Derived roughness approximation for dusty surface response
       roughnessPath: '/assets/textures/mars/roughness.jpg',
+      // MOLA global DEM heightmap
       heightmapPath: '/assets/textures/mars/heightmap.png',
       fallbackColor: 0xb5603c,
     },
@@ -52,6 +60,12 @@ const PLANET_CONFIGS: Record<PlanetType, PlanetConfig> = {
       maxLodLevel: 12,
       tileResolution: 256,
     },
+    landmarks: [
+      { name: 'Olympus Mons', lat: 18.65, lng: -133.8, description: 'Largest volcano in the Solar System' },
+      { name: 'Valles Marineris', lat: -14.6, lng: -59.3, description: 'Massive canyon system near equator' },
+      { name: 'Gale Crater', lat: -5.4, lng: 137.8, description: 'Curiosity rover landing site' },
+      { name: 'Jezero Crater', lat: 18.38, lng: 77.58, description: 'Perseverance rover landing site' },
+    ],
   },
   moon: {
     name: 'moon',
@@ -59,9 +73,13 @@ const PLANET_CONFIGS: Record<PlanetType, PlanetConfig> = {
     gravity: MOON_GRAVITY,
     segments: 128,
     textures: {
+      // LRO/LOLA global albedo map
       diffusePath: '/assets/textures/moon/diffuse.jpg',
+      // Height-derived normal map emphasizing crater rims
       normalPath: '/assets/textures/moon/normal.jpg',
+      // Approximate roughness map for regolith surface
       roughnessPath: '/assets/textures/moon/roughness.jpg',
+      // LOLA global elevation model
       heightmapPath: '/assets/textures/moon/heightmap.png',
       fallbackColor: 0x9a9a9a,
     },
@@ -76,6 +94,12 @@ const PLANET_CONFIGS: Record<PlanetType, PlanetConfig> = {
       maxLodLevel: 12,
       tileResolution: 256,
     },
+    landmarks: [
+      { name: 'Apollo 11 Landing Site', lat: 0.6741, lng: 23.4731, description: 'Sea of Tranquility' },
+      { name: 'Tycho Crater', lat: -43.31, lng: -11.36, description: 'Prominent young impact crater' },
+      { name: 'Copernicus Crater', lat: 9.62, lng: -20.08, description: 'Large ray crater' },
+      { name: 'Shackleton Crater', lat: -89.9, lng: 0, description: 'South pole crater with permanent shadow' },
+    ],
   },
 };
 
@@ -87,6 +111,8 @@ export class PlanetFactory {
       ...config,
       textures: { ...config.textures },
       atmosphere: config.atmosphere ? { ...config.atmosphere } : undefined,
+      terrain: config.terrain ? { ...config.terrain } : undefined,
+      landmarks: config.landmarks.map((landmark) => ({ ...landmark })),
     });
   }
 

--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -11,6 +11,7 @@ export interface PlayerControllerConfig {
   camera: THREE.PerspectiveCamera;
   input: InputManager;
   planetCenter: THREE.Vector3;
+  planetId?: string;
   planetRadius: number;
   surfaceMeshes: THREE.Object3D[];
   gravity?: number;
@@ -26,7 +27,7 @@ export class PlayerController implements IUpdatable, IDisposable {
   private readonly input: InputManager;
   private readonly gravity: SphericalGravity;
   private readonly collision: CollisionDetector;
-  private readonly surfaceMeshes: THREE.Object3D[];
+  private surfaceMeshes: THREE.Object3D[];
   private readonly planetCenter: THREE.Vector3;
 
   private moveSpeed: number;
@@ -42,6 +43,8 @@ export class PlayerController implements IUpdatable, IDisposable {
   private readonly _moveDir = new THREE.Vector3();
   private readonly _forward = new THREE.Vector3();
   private readonly _right = new THREE.Vector3();
+  private readonly _surfaceDir = new THREE.Vector3();
+  private readonly _worldUp = new THREE.Vector3(0, 1, 0);
 
   constructor(config: PlayerControllerConfig) {
     this.input = config.input;
@@ -52,7 +55,12 @@ export class PlayerController implements IUpdatable, IDisposable {
 
     // 初始位置：星球表面正上方
     const startPos = new THREE.Vector3(0, config.planetRadius + 2, 0);
-    this.state = new PlayerState(startPos);
+    this.state = new PlayerState(startPos, config.planetId ?? 'earth');
+    this.state.switchPlanet(config.planetId ?? 'earth', {
+      name: config.planetId ?? 'earth',
+      gravity: config.gravity ?? 9.81,
+      radius: config.planetRadius,
+    });
 
     this.gravity = new SphericalGravity(this.planetCenter);
     this.collision = new CollisionDetector(2);
@@ -149,6 +157,35 @@ export class PlayerController implements IUpdatable, IDisposable {
 
   private alignToSurface(dt: number): void {
     this.gravity.alignToSurface(this.state, dt);
+  }
+
+  switchPlanet(config: {
+    planetId: string;
+    planetRadius: number;
+    gravity: number;
+    surfaceMeshes: THREE.Object3D[];
+  }): void {
+    this.surfaceMeshes = config.surfaceMeshes;
+    this.state.switchPlanet(config.planetId, {
+      name: config.planetId,
+      gravity: config.gravity,
+      radius: config.planetRadius,
+    });
+    this.state.resetVelocity();
+    this.state.onGround = false;
+
+    this._surfaceDir
+      .copy(this.state.position)
+      .sub(this.planetCenter);
+    if (this._surfaceDir.lengthSq() < 1e-8) {
+      this._surfaceDir.set(0, 1, 0);
+    } else {
+      this._surfaceDir.normalize();
+    }
+
+    this.state.position.copy(this._surfaceDir).multiplyScalar(config.planetRadius + 2);
+    this.state.up.copy(this._surfaceDir);
+    this.state.quaternion.setFromUnitVectors(this._worldUp, this._surfaceDir);
   }
 
   dispose(): void {

--- a/src/player/PlayerState.ts
+++ b/src/player/PlayerState.ts
@@ -23,6 +23,7 @@ export class PlayerState {
 
   onGround = false;
   currentPlanet: string;
+  private gravityConfig: GravityConfig;
 
   constructor(initialPosition: THREE.Vector3, planet = 'earth') {
     this.position = initialPosition.clone();
@@ -30,18 +31,21 @@ export class PlayerState {
     this.quaternion = new THREE.Quaternion();
     this.up = new THREE.Vector3(0, 1, 0);
     this.currentPlanet = planet;
+    this.gravityConfig = PLANET_GRAVITY[planet] ?? PLANET_GRAVITY.earth;
   }
 
   /** 获取当前星球的重力配置 */
   getGravityConfig(): GravityConfig {
-    return PLANET_GRAVITY[this.currentPlanet] ?? PLANET_GRAVITY.earth;
+    return this.gravityConfig;
   }
 
   /** 切换星球 */
-  switchPlanet(planetId: string): void {
-    if (PLANET_GRAVITY[planetId]) {
-      this.currentPlanet = planetId;
-    }
+  switchPlanet(planetId: string, gravityConfig?: GravityConfig): void {
+    this.currentPlanet = planetId;
+    this.gravityConfig =
+      gravityConfig ??
+      PLANET_GRAVITY[planetId] ??
+      PLANET_GRAVITY.earth;
   }
 
   /** 重置速度 */

--- a/src/ui/PlanetSelector.ts
+++ b/src/ui/PlanetSelector.ts
@@ -1,0 +1,71 @@
+import type { IDisposable } from '../core/types';
+import type { PlanetType } from '../planet/PlanetFactory';
+
+export interface PlanetSelectorConfig {
+  initialPlanet: PlanetType;
+  onPlanetSelect: (planet: PlanetType) => void;
+}
+
+/** 星球切换面板：地球 / 火星 / 月球 */
+export class PlanetSelector implements IDisposable {
+  private readonly root: HTMLDivElement;
+  private readonly buttons: Record<PlanetType, HTMLButtonElement>;
+  private readonly onPlanetSelect: (planet: PlanetType) => void;
+
+  constructor(config: PlanetSelectorConfig) {
+    this.onPlanetSelect = config.onPlanetSelect;
+    this.root = document.createElement('div');
+    this.root.style.position = 'fixed';
+    this.root.style.top = '16px';
+    this.root.style.right = '16px';
+    this.root.style.display = 'flex';
+    this.root.style.gap = '8px';
+    this.root.style.padding = '10px';
+    this.root.style.background = 'rgba(6, 12, 22, 0.65)';
+    this.root.style.border = '1px solid rgba(155, 188, 255, 0.35)';
+    this.root.style.borderRadius = '10px';
+    this.root.style.backdropFilter = 'blur(4px)';
+    this.root.style.zIndex = '20';
+
+    this.buttons = {
+      earth: this.createButton('地球', 'earth'),
+      mars: this.createButton('火星', 'mars'),
+      moon: this.createButton('月球', 'moon'),
+    };
+
+    this.root.append(this.buttons.earth, this.buttons.mars, this.buttons.moon);
+    document.body.appendChild(this.root);
+    this.setActive(config.initialPlanet);
+  }
+
+  setActive(planet: PlanetType): void {
+    (Object.keys(this.buttons) as PlanetType[]).forEach((type) => {
+      const isActive = type === planet;
+      const button = this.buttons[type];
+      button.style.background = isActive ? '#78b7ff' : 'rgba(14, 26, 46, 0.9)';
+      button.style.color = isActive ? '#051224' : '#d9e8ff';
+      button.style.borderColor = isActive ? '#a8d4ff' : 'rgba(155, 188, 255, 0.45)';
+    });
+  }
+
+  dispose(): void {
+    this.root.remove();
+  }
+
+  private createButton(label: string, planet: PlanetType): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.textContent = label;
+    button.type = 'button';
+    button.style.padding = '6px 10px';
+    button.style.border = '1px solid rgba(155, 188, 255, 0.45)';
+    button.style.borderRadius = '6px';
+    button.style.fontSize = '12px';
+    button.style.fontFamily = 'ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif';
+    button.style.cursor = 'pointer';
+    button.style.transition = 'background-color 120ms ease, color 120ms ease, border-color 120ms ease';
+    button.addEventListener('click', () => {
+      this.onPlanetSelect(planet);
+    });
+    return button;
+  }
+}


### PR DESCRIPTION
## 完成内容
- PlanetLandmark接口+地标数据（珠峰/奥林帕斯山/阿波罗11等）
- PlanetSelector UI面板（地球/火星/月球切换按钮）
- SceneManager.replacePlanet()动态切换
- App集成星球切换+引力参数更新

Closes #7