### PR TITLE
feat: 轨道相机+太空地表过渡 #18

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -10,6 +10,7 @@ import { cartesianToGeo } from './utils/geo';
 import { HUD } from './ui/HUD';
 import { PlanetSelector } from './ui/PlanetSelector';
 import { PlayerController } from './player/PlayerController';
+import { CameraManager } from './camera/CameraManager';
 
 /** 主控制器：组装各子系统，驱动渲染循环 */
 export class App implements IDisposable {
@@ -20,6 +21,7 @@ export class App implements IDisposable {
   private hud: HUD;
   private planetSelector: PlanetSelector;
   private playerController: PlayerController;
+  private cameraManager: CameraManager;
   private clock = new THREE.Clock();
   private animationId = 0;
   private currentPlanet: PlanetType = 'earth';
@@ -50,6 +52,15 @@ export class App implements IDisposable {
       planetRadius: planet.config.radius,
       gravity: planet.config.gravity,
       surfaceMeshes: [planet.mesh],
+    });
+
+    this.cameraManager = new CameraManager({
+      camera: this.cameraSystem.camera,
+      domElement: canvas,
+      input: this.inputManager,
+      playerController: this.playerController,
+      getPlanetRadius: () => this.sceneManager.planetRadius,
+      planetCenter: new THREE.Vector3(0, 0, 0),
     });
 
     window.addEventListener('resize', this.onResize);
@@ -83,7 +94,7 @@ export class App implements IDisposable {
     const loop = (): void => {
       this.animationId = requestAnimationFrame(loop);
       const delta = this.clock.getDelta();
-      this.playerController.update(delta);
+      this.cameraManager.update(delta);
 
       const cameraPosition = this.cameraSystem.camera.position;
       const geo = cartesianToGeo(cameraPosition, this.sceneManager.planetRadius);
@@ -103,6 +114,7 @@ export class App implements IDisposable {
   dispose(): void {
     cancelAnimationFrame(this.animationId);
     window.removeEventListener('resize', this.onResize);
+    this.cameraManager.dispose();
     this.playerController.dispose();
     this.inputManager.dispose();
     this.hud.dispose();

--- a/src/camera/CameraManager.ts
+++ b/src/camera/CameraManager.ts
@@ -1,0 +1,157 @@
+import * as THREE from 'three';
+import type { IDisposable, IUpdatable } from '../core/types';
+import type { InputManager } from '../core/InputManager';
+import type { PlayerController } from '../player/PlayerController';
+import { OrbitMode } from './OrbitMode';
+import { TransitionController } from './TransitionController';
+
+export type CameraMode = 'orbit' | 'firstPerson';
+
+export interface CameraManagerConfig {
+  camera: THREE.PerspectiveCamera;
+  domElement: HTMLCanvasElement;
+  input: InputManager;
+  playerController: PlayerController;
+  getPlanetRadius: () => number;
+  planetCenter?: THREE.Vector3;
+  orbitMinAltitude?: number;
+  orbitMaxDistanceScale?: number;
+  autoEnterFirstPersonAltitude?: number;
+  autoEnterOrbitAltitude?: number;
+}
+
+/** 相机模式管理：轨道/第一人称切换 + 太空到地表过渡 */
+export class CameraManager implements IUpdatable, IDisposable {
+  readonly camera: THREE.PerspectiveCamera;
+  readonly orbitMode: OrbitMode;
+  readonly transitionController: TransitionController;
+
+  private readonly _input: InputManager;
+  private readonly _playerController: PlayerController;
+  private readonly _getPlanetRadius: () => number;
+  private readonly _planetCenter = new THREE.Vector3();
+
+  private readonly _orbitMinAltitude: number;
+  private readonly _orbitMaxDistanceScale: number;
+  private readonly _autoEnterFirstPersonAltitude: number;
+  private readonly _autoEnterOrbitAltitude: number;
+
+  private _mode: CameraMode = 'orbit';
+  private _isTransitioning = false;
+
+  constructor(config: CameraManagerConfig) {
+    this.camera = config.camera;
+    this._input = config.input;
+    this._playerController = config.playerController;
+    this._getPlanetRadius = config.getPlanetRadius;
+    this._planetCenter.copy(config.planetCenter ?? new THREE.Vector3(0, 0, 0));
+
+    this._orbitMinAltitude = config.orbitMinAltitude ?? 3.5;
+    this._orbitMaxDistanceScale = config.orbitMaxDistanceScale ?? 8;
+    this._autoEnterFirstPersonAltitude = config.autoEnterFirstPersonAltitude ?? 4.2;
+    this._autoEnterOrbitAltitude = Math.max(
+      config.autoEnterOrbitAltitude ?? 9,
+      this._autoEnterFirstPersonAltitude + 0.5,
+    );
+
+    this.orbitMode = new OrbitMode({
+      camera: this.camera,
+      domElement: config.domElement,
+      target: this._planetCenter,
+    });
+
+    this.transitionController = new TransitionController({
+      camera: this.camera,
+      planetCenter: this._planetCenter,
+      getPlanetRadius: this._getPlanetRadius,
+      atmosphereScale: 1.02,
+      surfaceOffset: 2,
+    });
+
+    this.applyOrbitDistanceLimits();
+    this.switchTo('orbit');
+  }
+
+  get mode(): CameraMode {
+    return this._mode;
+  }
+
+  switchTo(mode: CameraMode): void {
+    if (this._mode === mode && !this._isTransitioning) {
+      return;
+    }
+
+    if (mode === 'orbit') {
+      this._mode = 'orbit';
+      this._playerController.setEnabled(false);
+      this._input.setPointerLockEnabled(false);
+      this.orbitMode.syncFromCamera();
+      this.orbitMode.setEnabled(true);
+      return;
+    }
+
+    this._mode = 'firstPerson';
+    this.orbitMode.setEnabled(false);
+    this._playerController.syncToCamera(this.camera.position, this._planetCenter);
+    this._playerController.setEnabled(true);
+    this._input.setPointerLockEnabled(true);
+  }
+
+  update(delta: number): void {
+    this.applyOrbitDistanceLimits();
+    if (this._isTransitioning) {
+      return;
+    }
+
+    if (this._mode === 'orbit') {
+      this.orbitMode.update(delta);
+    } else {
+      this._playerController.update(delta);
+    }
+
+    this.autoSwitchByAltitude();
+  }
+
+  async animateToSurface(lat: number, lng: number, duration = 3000): Promise<void> {
+    this.switchTo('orbit');
+    this._isTransitioning = true;
+    this._input.setPointerLockEnabled(false);
+    this.orbitMode.setEnabled(false);
+
+    try {
+      await this.transitionController.animateToSurface(lat, lng, duration);
+      this._playerController.syncToCamera(this.camera.position, this._planetCenter);
+      this.switchTo('firstPerson');
+    } finally {
+      this._isTransitioning = false;
+    }
+  }
+
+  private applyOrbitDistanceLimits(): void {
+    const radius = this._getPlanetRadius();
+    this.orbitMode.setDistanceLimits(
+      radius + this._orbitMinAltitude,
+      radius * this._orbitMaxDistanceScale,
+    );
+  }
+
+  private autoSwitchByAltitude(): void {
+    const altitude = this.getCameraAltitude();
+    if (this._mode === 'orbit' && altitude <= this._autoEnterFirstPersonAltitude) {
+      this.switchTo('firstPerson');
+      return;
+    }
+    if (this._mode === 'firstPerson' && altitude >= this._autoEnterOrbitAltitude) {
+      this.switchTo('orbit');
+    }
+  }
+
+  private getCameraAltitude(): number {
+    return this.camera.position.distanceTo(this._planetCenter) - this._getPlanetRadius();
+  }
+
+  dispose(): void {
+    this.orbitMode.dispose();
+    this.transitionController.dispose();
+  }
+}

--- a/src/camera/OrbitMode.ts
+++ b/src/camera/OrbitMode.ts
@@ -1,0 +1,167 @@
+import * as THREE from 'three';
+import type { IDisposable, IUpdatable } from '../core/types';
+import { clamp } from '../utils/math';
+
+export interface OrbitModeConfig {
+  camera: THREE.PerspectiveCamera;
+  domElement: HTMLElement;
+  target?: THREE.Vector3;
+  minDistance?: number;
+  maxDistance?: number;
+  rotateSpeed?: number;
+  zoomSpeed?: number;
+  damping?: number;
+}
+
+/** 轨道相机模式：左键拖拽旋转，滚轮缩放，阻尼平滑 */
+export class OrbitMode implements IUpdatable, IDisposable {
+  readonly camera: THREE.PerspectiveCamera;
+  readonly domElement: HTMLElement;
+
+  enabled = false;
+  rotateSpeed: number;
+  zoomSpeed: number;
+  damping: number;
+  minDistance: number;
+  maxDistance: number;
+
+  private readonly _target = new THREE.Vector3();
+  private readonly _spherical = new THREE.Spherical();
+  private readonly _offset = new THREE.Vector3();
+
+  private _distance = 1;
+  private _phi = Math.PI * 0.5;
+  private _theta = 0;
+
+  private _targetDistance = 1;
+  private _targetPhi = Math.PI * 0.5;
+  private _targetTheta = 0;
+
+  private _isDragging = false;
+  private _lastMouseX = 0;
+  private _lastMouseY = 0;
+
+  constructor(config: OrbitModeConfig) {
+    this.camera = config.camera;
+    this.domElement = config.domElement;
+    this.rotateSpeed = config.rotateSpeed ?? 0.005;
+    this.zoomSpeed = config.zoomSpeed ?? 0.0018;
+    this.damping = config.damping ?? 10;
+    this.minDistance = config.minDistance ?? 10;
+    this.maxDistance = config.maxDistance ?? 10000;
+    this._target.copy(config.target ?? new THREE.Vector3(0, 0, 0));
+
+    this.syncFromCamera();
+    this.domElement.addEventListener('mousedown', this.onMouseDown);
+    window.addEventListener('mousemove', this.onMouseMove);
+    window.addEventListener('mouseup', this.onMouseUp);
+    this.domElement.addEventListener('wheel', this.onWheel, { passive: false });
+  }
+
+  setEnabled(enabled: boolean): void {
+    if (this.enabled === enabled) {
+      return;
+    }
+    this.enabled = enabled;
+    this._isDragging = false;
+    if (enabled) {
+      this.syncFromCamera();
+    }
+  }
+
+  setTarget(target: THREE.Vector3): void {
+    this._target.copy(target);
+    this.syncFromCamera();
+  }
+
+  setDistanceLimits(minDistance: number, maxDistance: number): void {
+    const clampedMin = Math.max(0.1, minDistance);
+    const clampedMax = Math.max(clampedMin, maxDistance);
+    this.minDistance = clampedMin;
+    this.maxDistance = clampedMax;
+    this._distance = clamp(this._distance, clampedMin, clampedMax);
+    this._targetDistance = clamp(this._targetDistance, clampedMin, clampedMax);
+  }
+
+  syncFromCamera(): void {
+    this._offset.copy(this.camera.position).sub(this._target);
+    if (this._offset.lengthSq() < 1e-8) {
+      this._offset.set(0, 0, 1);
+    }
+    this._spherical.setFromVector3(this._offset);
+    this._distance = clamp(this._spherical.radius, this.minDistance, this.maxDistance);
+    this._phi = clamp(this._spherical.phi, 1e-3, Math.PI - 1e-3);
+    this._theta = this._spherical.theta;
+    this._targetDistance = this._distance;
+    this._targetPhi = this._phi;
+    this._targetTheta = this._theta;
+    this.updateCameraTransform();
+  }
+
+  update(delta: number): void {
+    if (!this.enabled) return;
+
+    const alpha = 1 - Math.exp(-this.damping * Math.max(delta, 0));
+    this._distance += (this._targetDistance - this._distance) * alpha;
+    this._phi += (this._targetPhi - this._phi) * alpha;
+    this._theta += (this._targetTheta - this._theta) * alpha;
+    this._phi = clamp(this._phi, 1e-3, Math.PI - 1e-3);
+    this.updateCameraTransform();
+  }
+
+  private updateCameraTransform(): void {
+    this._spherical.radius = this._distance;
+    this._spherical.phi = this._phi;
+    this._spherical.theta = this._theta;
+    this._offset.setFromSpherical(this._spherical);
+    this.camera.position.copy(this._target).add(this._offset);
+    this.camera.up.set(0, 1, 0);
+    this.camera.lookAt(this._target);
+  }
+
+  private onMouseDown = (event: MouseEvent): void => {
+    if (!this.enabled || event.button !== 0) return;
+    this._isDragging = true;
+    this._lastMouseX = event.clientX;
+    this._lastMouseY = event.clientY;
+  };
+
+  private onMouseMove = (event: MouseEvent): void => {
+    if (!this.enabled || !this._isDragging) return;
+    const dx = event.clientX - this._lastMouseX;
+    const dy = event.clientY - this._lastMouseY;
+    this._lastMouseX = event.clientX;
+    this._lastMouseY = event.clientY;
+
+    this._targetTheta -= dx * this.rotateSpeed;
+    this._targetPhi = clamp(
+      this._targetPhi + dy * this.rotateSpeed,
+      1e-3,
+      Math.PI - 1e-3,
+    );
+  };
+
+  private onMouseUp = (event: MouseEvent): void => {
+    if (event.button === 0) {
+      this._isDragging = false;
+    }
+  };
+
+  private onWheel = (event: WheelEvent): void => {
+    if (!this.enabled) return;
+    event.preventDefault();
+    const scale = Math.exp(event.deltaY * this.zoomSpeed);
+    this._targetDistance = clamp(
+      this._targetDistance * scale,
+      this.minDistance,
+      this.maxDistance,
+    );
+  };
+
+  dispose(): void {
+    this.domElement.removeEventListener('mousedown', this.onMouseDown);
+    window.removeEventListener('mousemove', this.onMouseMove);
+    window.removeEventListener('mouseup', this.onMouseUp);
+    this.domElement.removeEventListener('wheel', this.onWheel);
+  }
+}

--- a/src/camera/TransitionController.ts
+++ b/src/camera/TransitionController.ts
@@ -1,0 +1,113 @@
+import * as THREE from 'three';
+import type { IDisposable } from '../core/types';
+import { geoToCartesian } from '../utils/geo';
+import { clamp } from '../utils/math';
+
+export interface TransitionControllerConfig {
+  camera: THREE.PerspectiveCamera;
+  planetCenter?: THREE.Vector3;
+  getPlanetRadius: () => number;
+  atmosphereScale?: number;
+  surfaceOffset?: number;
+}
+
+/** 太空→地表过渡控制器：按路径关键点执行平滑飞行动画 */
+export class TransitionController implements IDisposable {
+  readonly camera: THREE.PerspectiveCamera;
+
+  private readonly _planetCenter = new THREE.Vector3();
+  private readonly _getPlanetRadius: () => number;
+  private readonly _atmosphereScale: number;
+  private readonly _surfaceOffset: number;
+
+  private _rafId = 0;
+  private _activeResolve: (() => void) | null = null;
+
+  private readonly _start = new THREE.Vector3();
+  private readonly _atmosphere = new THREE.Vector3();
+  private readonly _surface = new THREE.Vector3();
+  private readonly _normal = new THREE.Vector3();
+  private readonly _tmp = new THREE.Vector3();
+
+  constructor(config: TransitionControllerConfig) {
+    this.camera = config.camera;
+    this._planetCenter.copy(config.planetCenter ?? new THREE.Vector3(0, 0, 0));
+    this._getPlanetRadius = config.getPlanetRadius;
+    this._atmosphereScale = config.atmosphereScale ?? 1.02;
+    this._surfaceOffset = config.surfaceOffset ?? 2;
+  }
+
+  async animateToSurface(lat: number, lng: number, duration = 3000): Promise<void> {
+    this.cancelCurrentAnimation();
+
+    const radius = this._getPlanetRadius();
+    const surfaceBase = geoToCartesian(lat, lng, radius).add(this._planetCenter);
+    this._normal.copy(surfaceBase).sub(this._planetCenter).normalize();
+    this._surface.copy(this._normal).multiplyScalar(radius + this._surfaceOffset).add(this._planetCenter);
+    this._atmosphere
+      .copy(this._normal)
+      .multiplyScalar(radius * this._atmosphereScale)
+      .add(this._planetCenter);
+    this._start.copy(this.camera.position);
+
+    if (duration <= 0) {
+      this.camera.position.copy(this._surface);
+      this.camera.lookAt(this._planetCenter);
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this._activeResolve = resolve;
+      const startTime = performance.now();
+      const split = 0.42;
+
+      const step = (now: number): void => {
+        const rawT = clamp((now - startTime) / duration, 0, 1);
+        const eased = this.easeInOutCubic(rawT);
+
+        if (eased < split) {
+          this._tmp.lerpVectors(this._start, this._atmosphere, eased / split);
+        } else {
+          this._tmp.lerpVectors(this._atmosphere, this._surface, (eased - split) / (1 - split));
+        }
+
+        this.camera.position.copy(this._tmp);
+        this.camera.lookAt(this._planetCenter);
+
+        if (rawT < 1) {
+          this._rafId = requestAnimationFrame(step);
+        } else {
+          this._rafId = 0;
+          this._activeResolve = null;
+          this.camera.position.copy(this._surface);
+          this.camera.lookAt(this._planetCenter);
+          resolve();
+        }
+      };
+
+      this._rafId = requestAnimationFrame(step);
+    });
+  }
+
+  private easeInOutCubic(t: number): number {
+    return t < 0.5
+      ? 4 * t * t * t
+      : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  }
+
+  private cancelCurrentAnimation(): void {
+    if (this._rafId !== 0) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = 0;
+    }
+    if (this._activeResolve) {
+      const resolve = this._activeResolve;
+      this._activeResolve = null;
+      resolve();
+    }
+  }
+
+  dispose(): void {
+    this.cancelCurrentAnimation();
+  }
+}

--- a/src/core/InputManager.ts
+++ b/src/core/InputManager.ts
@@ -12,6 +12,7 @@ export class InputManager implements IDisposable {
 
   private _mouseDelta: MouseDelta = { x: 0, y: 0 };
   private _pointerLocked = false;
+  private _pointerLockEnabled = true;
   private _jumpRequested = false;
   private readonly _canvas: HTMLCanvasElement | null;
 
@@ -21,9 +22,7 @@ export class InputManager implements IDisposable {
     window.addEventListener('keyup', this.onKeyUp);
     document.addEventListener('mousemove', this.onMouseMove);
     document.addEventListener('pointerlockchange', this.onPointerLockChange);
-    if (this._canvas) {
-      this._canvas.addEventListener('click', this.requestPointerLock);
-    }
+    this.bindPointerLockClick();
   }
 
   isPressed(code: string): boolean {
@@ -49,6 +48,23 @@ export class InputManager implements IDisposable {
 
   get pointerLocked(): boolean {
     return this._pointerLocked;
+  }
+
+  get pointerLockEnabled(): boolean {
+    return this._pointerLockEnabled;
+  }
+
+  setPointerLockEnabled(enabled: boolean): void {
+    if (this._pointerLockEnabled === enabled) {
+      return;
+    }
+    this._pointerLockEnabled = enabled;
+    this.bindPointerLockClick();
+    if (!enabled && this._pointerLocked) {
+      document.exitPointerLock();
+    }
+    this._mouseDelta.x = 0;
+    this._mouseDelta.y = 0;
   }
 
   /** 获取 WASD 移动方向 */
@@ -84,16 +100,23 @@ export class InputManager implements IDisposable {
   };
 
   private requestPointerLock = (): void => {
+    if (!this._pointerLockEnabled) return;
     this._canvas?.requestPointerLock();
   };
+
+  private bindPointerLockClick(): void {
+    if (!this._canvas) return;
+    this._canvas.removeEventListener('click', this.requestPointerLock);
+    if (this._pointerLockEnabled) {
+      this._canvas.addEventListener('click', this.requestPointerLock);
+    }
+  }
 
   dispose(): void {
     window.removeEventListener('keydown', this.onKeyDown);
     window.removeEventListener('keyup', this.onKeyUp);
     document.removeEventListener('mousemove', this.onMouseMove);
     document.removeEventListener('pointerlockchange', this.onPointerLockChange);
-    if (this._canvas) {
-      this._canvas.removeEventListener('click', this.requestPointerLock);
-    }
+    this._canvas?.removeEventListener('click', this.requestPointerLock);
   }
 }

--- a/src/player/PlayerController.ts
+++ b/src/player/PlayerController.ts
@@ -23,6 +23,7 @@ export interface PlayerControllerConfig {
 export class PlayerController implements IUpdatable, IDisposable {
   readonly state: PlayerState;
   readonly firstPerson: FirstPersonMode;
+  enabled = true;
 
   private readonly input: InputManager;
   private readonly gravity: SphericalGravity;
@@ -68,6 +69,8 @@ export class PlayerController implements IUpdatable, IDisposable {
   }
 
   update(delta: number): void {
+    if (!this.enabled) return;
+
     // 限制 delta 防止大跳帧
     const dt = Math.min(delta, 0.05);
 
@@ -78,6 +81,29 @@ export class PlayerController implements IUpdatable, IDisposable {
     this.applyVelocity(dt);
     this.resolveCollision();
     this.alignToSurface(dt);
+    this.firstPerson.update(this.state);
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  /** 将玩家状态与当前相机位置同步，避免模式切换跳变 */
+  syncToCamera(cameraPosition: THREE.Vector3, planetCenter: THREE.Vector3): void {
+    this._surfaceDir.copy(cameraPosition).sub(planetCenter);
+    if (this._surfaceDir.lengthSq() < 1e-8) {
+      this._surfaceDir.set(0, 1, 0);
+    } else {
+      this._surfaceDir.normalize();
+    }
+
+    this.state.up.copy(this._surfaceDir);
+    this.state.position
+      .copy(cameraPosition)
+      .addScaledVector(this._surfaceDir, -this.firstPerson.eyeHeight);
+    this.state.quaternion.setFromUnitVectors(this._worldUp, this._surfaceDir);
+    this.state.resetVelocity();
+    this.state.onGround = false;
     this.firstPerson.update(this.state);
   }
 


### PR DESCRIPTION
## 完成内容
- OrbitMode：左键拖拽旋转+滚轮缩放+阻尼平滑
- TransitionController：太空→地表三段过渡动画
- CameraManager：orbit/firstPerson模式管理+自动切换
- InputManager扩展PointerLock开关
- PlayerController增加启停和syncToCamera

Closes #18