### PR TITLE
feat: 地球特效 - 云层+夜景+海洋高光 #29

### DIFF
--- a/src/planet/Planet.ts
+++ b/src/planet/Planet.ts
@@ -3,6 +3,7 @@ import type { IDisposable } from '../core/types';
 import type { PlanetConfig } from './PlanetConfig';
 import { TerrainMaterial } from './terrain/TerrainMaterial';
 import { Atmosphere } from './atmosphere/Atmosphere';
+import { EarthEffects } from './effects/EarthEffects';
 
 /** 星球基类：球体网格 + 纹理 + 可选大气层 */
 export class Planet implements IDisposable {
@@ -11,6 +12,8 @@ export class Planet implements IDisposable {
   readonly mesh: THREE.Mesh<THREE.SphereGeometry, THREE.MeshStandardMaterial | TerrainMaterial>;
 
   private atmosphere?: Atmosphere;
+  private earthEffects?: EarthEffects;
+  private readonly sunDirection = new THREE.Vector3(1, 0.3, 0.5).normalize();
   private readonly textureLoader = new THREE.TextureLoader();
 
   constructor(config: PlanetConfig) {
@@ -71,6 +74,12 @@ export class Planet implements IDisposable {
       );
       this.root.add(this.atmosphere.mesh);
     }
+
+    // 地球特效：云层+夜景+海洋高光
+    if (config.name === 'earth') {
+      this.earthEffects = new EarthEffects(config.radius, config.segments);
+      this.root.add(this.earthEffects.root);
+    }
   }
 
   /**
@@ -129,12 +138,21 @@ export class Planet implements IDisposable {
     return texture;
   }
 
+  /** 每帧更新（地球特效等） */
+  update(delta: number): void {
+    this.earthEffects?.update(delta, this.sunDirection);
+  }
+
   dispose(): void {
     this.mesh.geometry.dispose();
     this.mesh.material.dispose();
 
     if (this.atmosphere) {
       this.atmosphere.dispose();
+    }
+
+    if (this.earthEffects) {
+      this.earthEffects.dispose();
     }
   }
 }

--- a/src/planet/effects/CloudLayer.ts
+++ b/src/planet/effects/CloudLayer.ts
@@ -1,0 +1,65 @@
+import * as THREE from 'three';
+import type { IDisposable } from '../../core/types';
+
+const CLOUD_TEXTURE_PATH = '/assets/textures/earth/clouds.jpg';
+const CLOUD_ALPHA_PATH = '/assets/textures/earth/clouds_alpha.jpg';
+
+/**
+ * 云层效果 — 半透明球壳，独立于星球缓慢自转
+ */
+export class CloudLayer implements IDisposable {
+  readonly mesh: THREE.Mesh<THREE.SphereGeometry, THREE.MeshPhongMaterial>;
+  private rotationSpeed = 0.002; // rad/s，略慢于地球自转
+
+  constructor(planetRadius: number, segments: number) {
+    const radius = planetRadius * 1.005;
+    const geometry = new THREE.SphereGeometry(radius, segments, segments);
+
+    const loader = new THREE.TextureLoader();
+    const material = new THREE.MeshPhongMaterial({
+      transparent: true,
+      opacity: 0.4,
+      depthWrite: false,
+      side: THREE.FrontSide,
+    });
+
+    // 纹理加载失败时静默跳过
+    loader.load(
+      CLOUD_TEXTURE_PATH,
+      (tex) => {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        tex.anisotropy = 8;
+        material.map = tex;
+        material.needsUpdate = true;
+      },
+      undefined,
+      () => { /* 静默跳过 */ },
+    );
+
+    loader.load(
+      CLOUD_ALPHA_PATH,
+      (tex) => {
+        tex.anisotropy = 8;
+        material.alphaMap = tex;
+        material.needsUpdate = true;
+      },
+      undefined,
+      () => { /* 静默跳过 */ },
+    );
+
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.name = 'earth-clouds';
+  }
+
+  update(delta: number): void {
+    this.mesh.rotation.y += this.rotationSpeed * delta;
+  }
+
+  dispose(): void {
+    this.mesh.geometry.dispose();
+    const mat = this.mesh.material;
+    mat.map?.dispose();
+    mat.alphaMap?.dispose();
+    mat.dispose();
+  }
+}

--- a/src/planet/effects/EarthEffects.ts
+++ b/src/planet/effects/EarthEffects.ts
@@ -1,0 +1,41 @@
+import * as THREE from 'three';
+import type { IDisposable } from '../../core/types';
+import { CloudLayer } from './CloudLayer';
+import { NightLights } from './NightLights';
+import { OceanEffect } from './OceanEffect';
+
+/**
+ * 地球特效管理器 — 组合云层+夜景+海洋高光
+ * 仅当 planetId === 'earth' 时激活
+ */
+export class EarthEffects implements IDisposable {
+  readonly root: THREE.Group;
+  private clouds: CloudLayer;
+  private nightLights: NightLights;
+  private ocean: OceanEffect;
+
+  constructor(planetRadius: number, segments: number) {
+    this.root = new THREE.Group();
+    this.root.name = 'earth-effects';
+
+    this.clouds = new CloudLayer(planetRadius, segments);
+    this.nightLights = new NightLights(planetRadius, segments);
+    this.ocean = new OceanEffect(planetRadius, segments);
+
+    this.root.add(this.clouds.mesh);
+    this.root.add(this.nightLights.mesh);
+    this.root.add(this.ocean.mesh);
+  }
+
+  update(delta: number, sunDirection: THREE.Vector3): void {
+    this.clouds.update(delta);
+    this.nightLights.setSunDirection(sunDirection);
+    this.ocean.setSunDirection(sunDirection);
+  }
+
+  dispose(): void {
+    this.clouds.dispose();
+    this.nightLights.dispose();
+    this.ocean.dispose();
+  }
+}

--- a/src/planet/effects/NightLights.ts
+++ b/src/planet/effects/NightLights.ts
@@ -1,0 +1,89 @@
+import * as THREE from 'three';
+import type { IDisposable } from '../../core/types';
+
+const NIGHT_TEXTURE_PATH = '/assets/textures/earth/night.jpg';
+
+const vertexShader = /* glsl */ `
+varying vec3 vNormal;
+varying vec2 vUv;
+varying vec3 vWorldPosition;
+
+void main() {
+  vUv = uv;
+  vNormal = normalize(normalMatrix * normal);
+  vec4 worldPos = modelMatrix * vec4(position, 1.0);
+  vWorldPosition = worldPos.xyz;
+  gl_Position = projectionMatrix * viewMatrix * worldPos;
+}
+`;
+
+const fragmentShader = /* glsl */ `
+uniform sampler2D nightMap;
+uniform vec3 sunDirection;
+
+varying vec3 vNormal;
+varying vec2 vUv;
+varying vec3 vWorldPosition;
+
+void main() {
+  vec3 normal = normalize(vNormal);
+  float dotNL = dot(normal, sunDirection);
+
+  // 暗面过渡：完全背光时全亮，过渡带平滑衰减
+  float nightFactor = smoothstep(-0.1, -0.3, dotNL);
+
+  vec4 nightColor = texture2D(nightMap, vUv);
+  gl_FragColor = vec4(nightColor.rgb * nightFactor, nightColor.a * nightFactor);
+}
+`;
+
+/**
+ * 夜景灯光 — 在星球暗面叠加城市灯光纹理
+ */
+export class NightLights implements IDisposable {
+  readonly mesh: THREE.Mesh<THREE.SphereGeometry, THREE.ShaderMaterial>;
+
+  constructor(planetRadius: number, segments: number) {
+    const radius = planetRadius * 1.001;
+    const geometry = new THREE.SphereGeometry(radius, segments, segments);
+
+    const material = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms: {
+        nightMap: { value: null },
+        sunDirection: { value: new THREE.Vector3(1, 0, 0) },
+      },
+      transparent: true,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+
+    const loader = new THREE.TextureLoader();
+    loader.load(
+      NIGHT_TEXTURE_PATH,
+      (tex) => {
+        tex.colorSpace = THREE.SRGBColorSpace;
+        tex.anisotropy = 8;
+        material.uniforms.nightMap.value = tex;
+      },
+      undefined,
+      () => { /* 静默跳过 */ },
+    );
+
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.name = 'earth-nightlights';
+  }
+
+  setSunDirection(dir: THREE.Vector3): void {
+    this.mesh.material.uniforms.sunDirection.value.copy(dir);
+  }
+
+  dispose(): void {
+    this.mesh.geometry.dispose();
+    const mat = this.mesh.material;
+    const nightMap = mat.uniforms.nightMap.value as THREE.Texture | null;
+    nightMap?.dispose();
+    mat.dispose();
+  }
+}

--- a/src/planet/effects/OceanEffect.ts
+++ b/src/planet/effects/OceanEffect.ts
@@ -1,0 +1,106 @@
+import * as THREE from 'three';
+import type { IDisposable } from '../../core/types';
+
+const OCEAN_MASK_PATH = '/assets/textures/earth/ocean_mask.jpg';
+
+const vertexShader = /* glsl */ `
+varying vec3 vNormal;
+varying vec3 vViewDir;
+varying vec2 vUv;
+
+void main() {
+  vUv = uv;
+  vNormal = normalize(normalMatrix * normal);
+  vec4 worldPos = modelMatrix * vec4(position, 1.0);
+  vViewDir = normalize(cameraPosition - worldPos.xyz);
+  gl_Position = projectionMatrix * viewMatrix * worldPos;
+}
+`;
+
+const fragmentShader = /* glsl */ `
+uniform sampler2D oceanMask;
+uniform vec3 sunDirection;
+uniform float fresnelPower;
+uniform float fresnelIntensity;
+uniform vec3 specularColor;
+
+varying vec3 vNormal;
+varying vec3 vViewDir;
+varying vec2 vUv;
+
+void main() {
+  vec3 normal = normalize(vNormal);
+  vec3 viewDir = normalize(vViewDir);
+
+  // 海洋 mask：白色=海洋
+  float mask = texture2D(oceanMask, vUv).r;
+
+  // Fresnel 反射
+  float fresnel = pow(1.0 - max(dot(normal, viewDir), 0.0), fresnelPower);
+  fresnel *= fresnelIntensity;
+
+  // 高光：基于太阳方向的 Blinn-Phong
+  vec3 halfDir = normalize(sunDirection + viewDir);
+  float spec = pow(max(dot(normal, halfDir), 0.0), 64.0);
+
+  // 仅在光照面显示高光
+  float sunFacing = max(dot(normal, sunDirection), 0.0);
+
+  vec3 color = specularColor * (fresnel + spec) * sunFacing * mask;
+  float alpha = (fresnel + spec) * sunFacing * mask;
+
+  gl_FragColor = vec4(color, alpha * 0.6);
+}
+`;
+
+/**
+ * 海洋高光 — Fresnel反射 + Blinn-Phong高光
+ */
+export class OceanEffect implements IDisposable {
+  readonly mesh: THREE.Mesh<THREE.SphereGeometry, THREE.ShaderMaterial>;
+
+  constructor(planetRadius: number, segments: number) {
+    const radius = planetRadius * 1.002;
+    const geometry = new THREE.SphereGeometry(radius, segments, segments);
+
+    const material = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms: {
+        oceanMask: { value: null },
+        sunDirection: { value: new THREE.Vector3(1, 0, 0) },
+        fresnelPower: { value: 3.0 },
+        fresnelIntensity: { value: 0.8 },
+        specularColor: { value: new THREE.Color(0.8, 0.9, 1.0) },
+      },
+      transparent: true,
+      depthWrite: false,
+    });
+
+    const loader = new THREE.TextureLoader();
+    loader.load(
+      OCEAN_MASK_PATH,
+      (tex) => {
+        tex.anisotropy = 8;
+        material.uniforms.oceanMask.value = tex;
+      },
+      undefined,
+      () => { /* 静默跳过 */ },
+    );
+
+    this.mesh = new THREE.Mesh(geometry, material);
+    this.mesh.name = 'earth-ocean';
+  }
+
+  setSunDirection(dir: THREE.Vector3): void {
+    this.mesh.material.uniforms.sunDirection.value.copy(dir);
+  }
+
+  dispose(): void {
+    this.mesh.geometry.dispose();
+    const mat = this.mesh.material;
+    const mask = mat.uniforms.oceanMask.value as THREE.Texture | null;
+    mask?.dispose();
+    mat.dispose();
+  }
+}


### PR DESCRIPTION
云层自转+夜景灯光+海洋Fresnel高光，仅地球生效。Closes #29